### PR TITLE
Get katpoint from master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ idna
 ipaddress
 jinja2
 jmespath
-katpoint==0.7
 katversion
 llvmlite
 markupsafe==1.0
@@ -44,5 +43,6 @@ tornado==5.1.1
 urllib3
 
 katdal @ git+https://github.com/ska-sa/katdal
+katpoint @ git+https://github.com/ska-sa/katpoint
 katsdpservices @ git+https://github.com/ska-sa/katsdpservices
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate


### PR DESCRIPTION
katdal is already fetched from master, and there are often dependencies
between them. In this case katdal switched to specifying katpoint>=0.9
which broke the build.