### PR TITLE
Fix S3ChunkStore construction

### DIFF
--- a/katsdpdatawriter/spead_write.py
+++ b/katsdpdatawriter/spead_write.py
@@ -697,7 +697,7 @@ def chunk_store_from_args(parser: argparse.ArgumentParser,
         chunk_store = katdal.chunkstore_npy.NpyFileChunkStore(
             args.npy_path, direct_write=args.direct_write)
     else:
-        chunk_store = katdal.chunkstore_s3.S3ChunkStore.from_url(
+        chunk_store = katdal.chunkstore_s3.S3ChunkStore(
             args.s3_endpoint_url,
             credentials=(args.s3_access_key, args.s3_secret_key),
             expiry_days=args.s3_expiry_days or 0)

--- a/katsdpdatawriter/test/test_spead_write.py
+++ b/katsdpdatawriter/test/test_spead_write.py
@@ -164,14 +164,14 @@ class TestChunkStoreFromArgs:
         m.assert_called_with('/', direct_write=True)
 
     def test_s3(self, error):
-        with mock.patch('katdal.chunkstore_s3.S3ChunkStore.from_url') as m:
+        with mock.patch('katdal.chunkstore_s3.S3ChunkStore') as m:
             chunk_store_from_args(self.parser, self.parser.parse_args(
                 ['--s3-endpoint-url=https://s3.invalid',
                  '--s3-secret-key=S3CR3T', '--s3-access-key', 'ACCESS']))
         m.assert_called_with('https://s3.invalid', credentials=('ACCESS', 'S3CR3T'), expiry_days=0)
 
     def test_s3_expire(self, error):
-        with mock.patch('katdal.chunkstore_s3.S3ChunkStore.from_url') as m:
+        with mock.patch('katdal.chunkstore_s3.S3ChunkStore') as m:
             chunk_store_from_args(self.parser, self.parser.parse_args(
                 ['--s3-endpoint-url=https://s3.invalid',
                  '--s3-secret-key=S3CR3T', '--s3-access-key', 'ACCESS',


### PR DESCRIPTION
The `from_url` method has been removed by ska-sa/katdal#272 and is replaced by the more straightforward class __init__.