### PR TITLE
Update requirements to match katsdpdockerbase update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ jinja2
 jmespath
 katversion
 llvmlite
-markupsafe==1.0
+markupsafe
 msgpack
 netifaces
 numba
@@ -40,7 +40,7 @@ six
 spead2
 terminaltables
 toolz
-tornado==5.1.1
+tornado
 urllib3
 
 katdal @ git+https://github.com/ska-sa/katdal

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cityhash
 dask
 decorator
 docutils
-fakeredis
+ephem
 future
 h5py
 hiredis

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ future
 h5py
 hiredis
 idna
-ipaddress
 jinja2
 jmespath
 katversion


### PR DESCRIPTION
This should be merged together with ska-sa/katsdpdockerbase#46. It may
currently fail to build until that branch is merged.